### PR TITLE
Parse deleted value in SR_OP_DELETED / SR_OP_MODIFIED

### DIFF
--- a/sysrepo/change.py
+++ b/sysrepo/change.py
@@ -27,7 +27,7 @@ class Change:
     def parse(
         operation: int,
         node: libyang.DNode,
-        prev_val: str,
+        prev_val: Any,
         prev_list: str,
         prev_dflt: bool,
         include_implicit_defaults: bool = True,
@@ -83,7 +83,9 @@ class Change:
                 prev_dflt=prev_dflt,
             )
         if operation == lib.SR_OP_DELETED:
-            return ChangeDeleted(node.path())
+            return ChangeDeleted(
+                node.path(),
+                prev_val=prev_val)
         if operation == lib.SR_OP_MOVED:
             return ChangeMoved(
                 node.path(),
@@ -136,7 +138,7 @@ class ChangeModified(Change):
 
     __slots__ = ("value", "prev_val", "prev_dflt")
 
-    def __init__(self, xpath: str, value: Any, prev_val: str, prev_dflt: bool = False):
+    def __init__(self, xpath: str, value: Any, prev_val: Any, prev_dflt: bool = False):
         super().__init__(xpath)
         self.value = value
         self.prev_val = prev_val
@@ -156,7 +158,12 @@ class ChangeModified(Change):
 
 # ------------------------------------------------------------------------------
 class ChangeDeleted(Change):
-    pass
+
+    __slots__ = ("prev_val",)
+
+    def __init__(self, xpath: str, prev_val: Any):
+        super().__init__(xpath)
+        self.prev_val = prev_val
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Right now the libyang function `sr_get_change_tree_next` is being used (`Session.get_changes()`), in which the following limitations have been detected:

* For `SR_OP_DELETED`, `prev_value` is always `NULL`, so we cannot know the previous value of a deleted node.
* For `SR_OP_MODIFIED`, `prev_value` is returned, but it is always parsed as string, which may not be coherent with data type being used in Sysrepo datastore.

This workaround introduces these changes:

* For both `SR_OP_DELETED` and `SR_OP_MODIFIED` operations it uses `sr_get_change_next`, which gives us `sr_val_t` data type `old_value` and `new_value` elements, but it does not return a `lyd_node` type element. In these cases, `old_value` is parsed using `Value.parse()` method and it is passed as `prev_val` to `Change.parse()`.
* In `Change.parse()` and `ChangeModified.__init__()` methods, `prev_val` type has been changed from `str` to `Any`.
* In `ChangeDeleted.__init__()`, `prev_val` has been introduced as attribute, with `Any` type.