### PR TITLE
Add deleted value to ChangeDeleted

### DIFF
--- a/sysrepo/change.py
+++ b/sysrepo/change.py
@@ -83,7 +83,9 @@ class Change:
                 prev_dflt=prev_dflt,
             )
         if operation == lib.SR_OP_DELETED:
-            return ChangeDeleted(node.path())
+            return ChangeDeleted(
+                node.path(),
+                _node_value(node, include_implicit_defaults))
         if operation == lib.SR_OP_MOVED:
             return ChangeMoved(
                 node.path(),
@@ -156,7 +158,21 @@ class ChangeModified(Change):
 
 # ------------------------------------------------------------------------------
 class ChangeDeleted(Change):
-    pass
+
+    __slots__ = "value"
+
+    def __init__(self, xpath: str, value: Any):
+        super().__init__(xpath)
+        self.value = value
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            super().__eq__(other)
+            and other.value == self.value
+        )
+
+    def __str__(self) -> str:
+        return "%s: %r" % (self.xpath, self.value)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
We can get deleted value from _node_ argument passed in `Change.parse()`, so we can add this additional attribute to `ChangeDeleted`.